### PR TITLE
Add Vitest setup and sample test

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
-    "postinstall": "nuxt prepare"
+    "postinstall": "nuxt prepare",
+    "test": "vitest"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.3",
@@ -17,8 +18,12 @@
     "vue-router": "^4.5.0"
   },
   "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.4",
+    "@vue/test-utils": "^2.4.1",
+    "jsdom": "^24.0.0",
     "sass": "^1.86.3",
     "sass-embedded": "^1.86.3",
-    "sass-loader": "^16.0.5"
+    "sass-loader": "^16.0.5",
+    "vitest": "^1.5.2"
   }
 }

--- a/tests/AlkhimiaModal.spec.ts
+++ b/tests/AlkhimiaModal.spec.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import AlkhimiaModal from '../components/AlkhimiaModal.vue'
+
+describe('AlkhimiaModal imageSrc', () => {
+  it('returns correct path for alquimia', () => {
+    const wrapper = mount(AlkhimiaModal, {
+      props: { isOpen: true, typeKnowledge: 'alquimia' }
+    })
+    expect((wrapper.vm as any).imageSrc).toBe('../assets/images/albedo.png')
+  })
+
+  it('returns correct path for magia', () => {
+    const wrapper = mount(AlkhimiaModal, {
+      props: { isOpen: true, typeKnowledge: 'magia' }
+    })
+    expect((wrapper.vm as any).imageSrc).toBe('../assets/images/baton.png')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  test: {
+    environment: 'jsdom'
+  }
+})


### PR DESCRIPTION
## Summary
- configure Vitest dev dependencies and test script
- add Vitest config for Vue + jsdom
- provide AlkhimiaModal unit tests checking image path

## Testing
- `npm run test` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6848a7d84aac83309142cab5f556f2ae