### PR TITLE
Fix responsive menu icon overlap

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -85,11 +85,14 @@
 
       <!-- Navbar Mobile -->
       <div class="flex md:hidden items-center justify-center mb-4 relative">
-        <h1 ref="gradient" class="text-3xl antiga-bold mb-0 text-center w-full">
+        <h1
+          ref="gradient"
+          class="text-3xl antiga-bold mb-0 text-center w-full pr-16"
+        >
           Magick & Alkhemya
         </h1>
         <button
-          class="absolute right-4"
+          class="absolute right-4 top-1/2 -translate-y-1/2"
           @click="showMobileMenu = true"
           aria-label="Abrir menu"
         >


### PR DESCRIPTION
## Summary
- adjust mobile header padding and menu button position so the icon doesn't cover the title

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e0adfeda88330837dcfa85bb7ba32